### PR TITLE
clase ph-metro

### DIFF
--- a/pH4502c/Examples/ReadMe
+++ b/pH4502c/Examples/ReadMe
@@ -1,1 +1,2 @@
-Proximamente, solo en el lab
+Main.cpp contiene un ejemplo que no implementa la clase de ph, implementa el funcionamiento basico del sensor implementado la formula necesaria para la conversión del voltaje al equivalente de ph
+

--- a/pH4502c/Examples/ReadMe
+++ b/pH4502c/Examples/ReadMe
@@ -1,0 +1,1 @@
+Proximamente, solo en el lab

--- a/pH4502c/Examples/main.cpp
+++ b/pH4502c/Examples/main.cpp
@@ -1,0 +1,40 @@
+#include <Arduino.h>
+const int analogInPin = A0;
+int sensorValue = 0;
+unsigned long int avgValue;
+float b;
+;
+void setup() {
+ Serial.begin(9600);
+}
+
+void loop() {
+ for(int i=0;i<10;i++)
+ {
+  buf[i]=analogRead(analogInPin)-330;
+  Serial.println(buf[i]);
+  delay(100);
+ }
+ for(int i=0;i<9;i++)
+ {
+  for(int j=i+1;j<10;j++)
+  {
+   if(buf[i]>buf[j])
+   {
+    temp=buf[i];
+    buf[i]=buf[j];
+    buf[j]=temp;
+   }
+  }
+ }
+ avgValue=0;
+ for(int i=2;i<8;i++)
+ avgValue+=buf[i];
+ float pHVol=(float)avgValue*5.0/1024/6;
+ float phValue = 2.4 * pHVol + 1;
+ Serial.print("sensor = ");
+ Serial.println(phValue);
+
+
+ delay(20);
+}

--- a/pH4502c/pH4502c.cpp
+++ b/pH4502c/pH4502c.cpp
@@ -1,0 +1,40 @@
+#include <pH4502c.h>
+
+pH4502c::pH4502c(PCF8591 _pcf, uint8_t _pin, void(*_callback)(float_t))
+  : pcf(_pcf), pin(_pin), callback(_callback)
+{
+  Serial.print("pin");
+  Serial.println(pin);
+}
+
+
+float_t pH4502c::lecturaAnalogica(){
+  int buf[10],temp;
+  unsigned long int avgValue;
+  for(int i=0;i<10;i++)
+  {
+   buf[i]=this->pcf.lecturaAnalogica(pin)-330;
+   Serial.println(buf[i]);
+   //delay(100)
+  }
+  for(int i=0;i<9;i++)
+  {
+   for(int j=i+1;j<10;j++)
+   {
+    if(buf[i]>buf[j])
+    {
+     temp=buf[i];
+     buf[i]=buf[j];
+     buf[j]=temp;
+    }
+   }
+  }
+  avgValue=0;
+  for(int i=2;i<8;i++)
+  avgValue+=buf[i];
+  this->pHVol=(float)avgValue*5.0/1024/6;
+  this->pHVal = 2.4 * this->pHVol + 1;
+  Serial.print("sensor = ");
+  this->callback(this->pHVal);
+  return this->pHVal;
+}

--- a/pH4502c/pH4502c.h
+++ b/pH4502c/pH4502c.h
@@ -1,0 +1,23 @@
+#ifndef PH4502C_H
+#define PH4502C_H
+
+#include <Arduino.h>
+#include "PCF8591.h"
+class pH4502c {
+  private:
+    uint8_t medida;
+    float_t pHVol;
+    float_t pHVal;
+    PCF8591& pcf;
+    void(*callback)(float_t);
+    uint8_t pin;
+
+  public:
+    //Retorna valores bi-decimales de entre 0-14
+    //De acuerdo a la escala de pH
+    float_t lecturaAnalogica();
+    pH4502c(PCF8591 _pcf, uint8_t _pin, void(*_callback)(float_t) );
+
+
+};
+#endif


### PR DESCRIPTION
Clase pH4502c con un PCF8591 para una correcta medicion del ph en una sustancia, hasta el momento hacen falta diferentes sustancias con ph's de 4, 7 y 10 para una correcta calibración del sensor, ademas hace falta tambien ejemplos de uso,