### PR TITLE
Enumeracion de pines para clase PCF8574

### DIFF
--- a/PCF8574/PCF8574.h
+++ b/PCF8574/PCF8574.h
@@ -29,6 +29,7 @@ public:
   void begin();
   void write(uint8_t pin, uint8_t value);
   uint8_t read(uint8_t pin);
+  enum PINS {P0 = 0, P1, P2, P3, P4, P5, P6, P7};
 };
 
 #endif


### PR DESCRIPTION
# Descripción

Implementación de enumeración de pines para clase `PCF8574`. Se agregó un miembro de tipo `enum PINS` que contene los pines disponibles a usar para lectura/escritura de datos por el `PCF8574`, contemplando el rango `P0, P1,...., P7`.

Fixes #14 